### PR TITLE
Add automated build and push workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+jobs:
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get version
+        id: vars
+        run: echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+        #   platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ github.repository }}:latest,${{ github.repository }}:${{ steps.vars.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-        #   platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.repository }}:latest,${{ github.repository }}:${{ steps.vars.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ Stop the container and remove it with:
 docker container stop hiya
 docker container rm hiya
 ```
+
+## Automatically build and push image
+
+I set up a CI workflow in [release.yml](./.github/workflows/release.yml)
+to build the *hellow-docker* image and push it to Docker Hub.
+The workflow only runs when the repo is tagged.
+Just push the tag to GitHub and the workflow handles the rest.


### PR DESCRIPTION
Docker has developed a series of actions that allow an image to be built and pushed to Docker Hub. In this PR, I set up a workflow that, on a tagged release, builds the *hello-docker* image on two platforms (linux/amd64 and linux/arm64) and pushes them. All I have to do is tag the repo and push the tag; the workflow takes care of the rest. The workflow is only run on `git push --tags`.